### PR TITLE
Add Docker deployment stack

### DIFF
--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -1,0 +1,17 @@
+# Copy this file to .env before running docker compose to customize the deployment.
+# Any value left blank will fall back to the defaults defined in docker-compose.yml.
+
+# Application metadata
+APP_NAME=FurtherAI SQL Agent
+ENVIRONMENT=production
+ALLOWED_ORIGINS=*
+
+# Agent behaviour
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini
+MAX_REASONING_STEPS=5
+ALLOW_MCP=true
+ALLOW_TOOL_CALLING=true
+
+# Database connection used by the backend container
+DATABASE_URL=postgresql+psycopg://furtherai:furtherai@db:5432/furtherai

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -1,0 +1,50 @@
+# Docker Deployment
+
+This directory contains a reference Docker Compose stack for running the FurtherAI SQL Agent, including:
+
+- **PostgreSQL** for conversation storage
+- **FastAPI backend** serving the API and agent endpoints
+- **Nginx frontend** that hosts the static UI and proxies `/api` traffic to the backend
+
+## Prerequisites
+
+- [Docker Engine](https://docs.docker.com/engine/install/) 20.10+
+- [Docker Compose](https://docs.docker.com/compose/install/) V2 (usually bundled with modern Docker Desktop / CLI)
+
+## Quick start
+
+1. Copy the example environment file and edit it to suit your environment:
+
+   ```bash
+   cp .env.example .env
+   # update .env with your OPENAI_API_KEY, etc.
+   ```
+
+2. Build and launch the stack:
+
+   ```bash
+   docker compose up --build
+   ```
+
+   The command exposes:
+
+   - Frontend UI on [http://localhost:8080](http://localhost:8080)
+   - Backend API on [http://localhost:8000](http://localhost:8000)
+
+3. (Optional) Run the services in the background:
+
+   ```bash
+   docker compose up --build -d
+   ```
+
+4. Tear everything down (containers + named volume):
+
+   ```bash
+   docker compose down -v
+   ```
+
+## Notes
+
+- The backend automatically runs database migrations via SQLAlchemy metadata creation at startup.
+- The default database credentials are intended for local development only. Update them before deploying to production.
+- To adjust the OpenAI model or reasoning parameters, edit the values in `.env` or override them when running `docker compose`.

--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1.5
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install build dependencies for psycopg and clean up
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY backend/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend/app ./app
+
+# Create a non-root user to run the service
+RUN useradd -m appuser
+USER appuser
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  db:
+    image: postgres:15-alpine
+    container_name: furtherai-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: furtherai
+      POSTGRES_USER: furtherai
+      POSTGRES_PASSWORD: furtherai
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U furtherai"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/backend.Dockerfile
+    container_name: furtherai-backend
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://furtherai:furtherai@db:5432/furtherai}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-4o-mini}
+      MAX_REASONING_STEPS: ${MAX_REASONING_STEPS:-5}
+      ALLOW_MCP: ${ALLOW_MCP:-true}
+      ALLOW_TOOL_CALLING: ${ALLOW_TOOL_CALLING:-true}
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-*}
+      ENVIRONMENT: ${ENVIRONMENT:-production}
+      APP_NAME: ${APP_NAME:-FurtherAI SQL Agent}
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/frontend.Dockerfile
+    container_name: furtherai-frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    ports:
+      - "8080:80"
+
+volumes:
+  postgres_data:

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx:1.27-alpine
+
+COPY deploy/docker/nginx.conf /etc/nginx/nginx.conf
+COPY frontend /usr/share/nginx/html
+
+EXPOSE 80

--- a/deploy/docker/nginx.conf
+++ b/deploy/docker/nginx.conf
@@ -1,0 +1,35 @@
+events {
+  worker_connections 1024;
+}
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+  sendfile      on;
+  keepalive_timeout 65;
+
+  upstream backend {
+    server backend:8000;
+  }
+
+  server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+      try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+      proxy_pass http://backend:8000;
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add docker compose stack for backend, frontend, and postgres services
- provide Dockerfiles for the FastAPI backend and Nginx-hosted frontend
- document environment configuration and startup steps for containerized deployment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d812dc3acc832692636f06ee134c27